### PR TITLE
Fix buffer overflow in context line

### DIFF
--- a/src/flrn_command.c
+++ b/src/flrn_command.c
@@ -551,7 +551,7 @@ int Lit_cmd_key(struct key_entry *, int, int, Cmd_return *);
 int Lit_cmd_explicite(flrn_char *, int, int, Cmd_return *);
 
 static int aff_context(int princip, int second) {
-   flrn_char chaine[18];
+   flrn_char chaine[128];
 
    chaine[0]=fl_static('(');
    fl_strcpy(&(chaine[1]),Noms_contextes[princip]);


### PR DESCRIPTION
The highest chain found so far is "(command/pager) : ", which is 18
chars, and provokes a buffer overflow if we add the final \0 to it. This
change makes sure it has a reasonnable space to avoid that.